### PR TITLE
Fix false-positive API-shape alerts on state transitions

### DIFF
--- a/api_monitor.go
+++ b/api_monitor.go
@@ -12,84 +12,132 @@ import (
 	"sync"
 )
 
-// APIShapeMonitor detects when the JSON structure of PrusaLink API responses
-// changes between poll cycles — for example when an unknown object is received
-// that was not present before. On first call for a printer+endpoint pair the
-// response is stored as the baseline. Subsequent calls return the field diff.
+// APIShapeMonitor detects fields in PrusaLink API responses that the
+// application does not know about. It diffs each response body against a
+// per-endpoint schema (the set of field paths the structs declare, plus
+// state- and lifecycle-dependent keys the API may or may not emit) and
+// alerts only on paths outside that schema.
 //
-// Muting rules (all state is in-memory; resets on process restart):
-//   - alertPending: true while an unacknowledged API-change alert exists for a
-//     printer. Blocks new alerts until ClearAlert is called (i.e. user dismisses).
-//   - muted: true after the user explicitly mutes a printer. Suppresses all
-//     further alerts until UnmuteOnPrint is called (on IDLE→PRINTING transition).
+// Diff is against the schema, not against the first body seen. The first
+// body is unreliable as a baseline: it may be missing state-dependent
+// fields (e.g. time_remaining absent on FINISHED), which would lock in a
+// partial schema and trigger a false positive the first time a print starts.
+//
+// Muting rules (in-memory; reset on process restart):
+//   - alertPending: true while an unacknowledged alert exists. Blocks new
+//     alerts until ClearAlert is called (user dismisses).
+//   - muted: true after user mutes. Suppresses alerts until UnmuteOnPrint
+//     (on IDLE→PRINTING).
 type APIShapeMonitor struct {
 	mu           sync.Mutex
-	shapes       map[string]string // "printerID:endpoint" → sorted field-path fingerprint
-	alertPending map[string]bool   // printerID → alert is live and unacknowledged
-	muted        map[string]bool   // printerID → muted until next print / restart
+	schema       map[string]map[string]bool // endpoint → known field paths
+	alertPending map[string]bool            // printerID → alert is live and unacknowledged
+	muted        map[string]bool            // printerID → muted until next print / restart
 }
 
 // NewAPIShapeMonitor creates a ready-to-use monitor.
 func NewAPIShapeMonitor() *APIShapeMonitor {
 	return &APIShapeMonitor{
-		shapes:       make(map[string]string),
+		schema: map[string]map[string]bool{
+			"status": statusSchema(),
+			"job":    jobSchema(),
+		},
 		alertPending: make(map[string]bool),
 		muted:        make(map[string]bool),
 	}
 }
 
-// Check compares the JSON shape of body against the stored baseline for
-// printerID+endpoint. On first call the body is stored as the baseline and
-// (nil, nil, false) is returned. On subsequent calls a diff is returned when
-// the field set changes.
-//
-// Returns (added, removed []string, changed bool).
-// added/removed are slash-prefixed paths, e.g. "/printer/temp_nozzle".
-func (m *APIShapeMonitor) Check(printerID, endpoint string, body []byte) (added, removed []string, changed bool) {
+// statusSchema is the allow-list of field paths /api/v1/status may return.
+// Mirrors PrusaLinkStatus (prusalink.go) and adds state-/lifecycle-dependent
+// keys the API may emit but the struct does not decode:
+//   - storage: optional across firmware versions
+//   - job: present while printing, absent when idle/finished
+//   - transfer: present only during file uploads
+//   - printer.axis_x / axis_y: present when idle, absent while printing (Core One L)
+func statusSchema() map[string]bool {
+	return map[string]bool{
+		"/job":                        true,
+		"/job/id":                     true,
+		"/job/progress":               true,
+		"/job/time_remaining":         true,
+		"/job/time_printing":          true,
+		"/storage":                    true,
+		"/storage/path":               true,
+		"/storage/name":               true,
+		"/storage/read_only":          true,
+		"/printer":                    true,
+		"/printer/state":              true,
+		"/printer/temp_nozzle":        true,
+		"/printer/target_nozzle":      true,
+		"/printer/temp_bed":           true,
+		"/printer/target_bed":         true,
+		"/printer/axis_x":             true,
+		"/printer/axis_y":             true,
+		"/printer/axis_z":             true,
+		"/printer/flow":               true,
+		"/printer/speed":              true,
+		"/printer/fan_hotend":         true,
+		"/printer/fan_print":          true,
+		"/transfer":                   true,
+		"/transfer/id":                true,
+		"/transfer/progress":          true,
+		"/transfer/time_transferring": true,
+		"/transfer/transferred":       true,
+	}
+}
+
+// jobSchema is the allow-list of field paths /api/v1/job may return.
+// Mirrors PrusaLinkJob (prusalink.go). All fields are state- or
+// file-dependent and may legitimately be absent; the list is the
+// allow-list, not a required set.
+func jobSchema() map[string]bool {
+	return map[string]bool{
+		"/id":                   true,
+		"/state":                true,
+		"/progress":             true,
+		"/time_remaining":       true,
+		"/time_printing":        true,
+		"/file":                 true,
+		"/file/name":            true,
+		"/file/display_name":    true,
+		"/file/path":            true,
+		"/file/size":            true,
+		"/file/m_timestamp":     true,
+		"/file/refs":            true,
+		"/file/refs/download":   true,
+		"/file/refs/icon":       true,
+		"/file/refs/thumbnail":  true,
+		"/filament":             true,
+		"/filament/toolhead_id": true,
+		"/filament/length":      true,
+		"/filament/weight":      true,
+	}
+}
+
+// Check returns the field paths in body that are not in the schema for
+// endpoint. removed is always nil — known fields may legitimately
+// disappear with state, so their absence is not an alert-worthy event.
+// Returns (added, nil, false) for empty body, unparseable JSON, or an
+// unknown endpoint.
+func (m *APIShapeMonitor) Check(endpoint string, body []byte) (added, removed []string, changed bool) {
 	if len(body) == 0 {
 		return nil, nil, false
 	}
-
 	var v interface{}
 	if err := json.Unmarshal(body, &v); err != nil {
 		return nil, nil, false
 	}
-
-	paths := jsonFieldPaths(v, "")
-	sort.Strings(paths)
-	fingerprint := strings.Join(paths, "\n")
-
-	key := printerID + ":" + endpoint
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	prev, seen := m.shapes[key]
-	m.shapes[key] = fingerprint
-
-	if !seen {
+	known, ok := m.schema[endpoint]
+	if !ok {
 		return nil, nil, false
 	}
-	if prev == fingerprint {
-		return nil, nil, false
-	}
-
-	prevSet := splitSet(prev)
-	currSet := splitSet(fingerprint)
-
-	for p := range currSet {
-		if !prevSet[p] {
+	for _, p := range jsonFieldPaths(v, "") {
+		if !known[p] {
 			added = append(added, p)
 		}
 	}
-	for p := range prevSet {
-		if !currSet[p] {
-			removed = append(removed, p)
-		}
-	}
 	sort.Strings(added)
-	sort.Strings(removed)
-	return added, removed, true
+	return added, nil, len(added) > 0
 }
 
 // ShouldAlert returns true if an API-change alert should be fired for this
@@ -167,14 +215,4 @@ func jsonFieldPaths(v interface{}, prefix string) []string {
 	default:
 		return nil
 	}
-}
-
-func splitSet(fingerprint string) map[string]bool {
-	set := make(map[string]bool)
-	for _, line := range strings.Split(fingerprint, "\n") {
-		if line != "" {
-			set[line] = true
-		}
-	}
-	return set
 }

--- a/api_monitor_test.go
+++ b/api_monitor_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"os"
 	"testing"
 )
@@ -66,103 +65,135 @@ func TestJsonFieldPaths_Array(t *testing.T) {
 	}
 }
 
-// ─── APIShapeMonitor ──────────────────────────────────────────────────────────
+// ─── APIShapeMonitor — schema-based diff ──────────────────────────────────────
 
-func TestAPIShapeMonitor_FirstCall_NoChange(t *testing.T) {
+// All-known body should never alert.
+func TestAPIShapeMonitor_AllKnown_NoAlert(t *testing.T) {
 	m := NewAPIShapeMonitor()
-	body := []byte(`{"printer":{"state":"IDLE"}}`)
-	added, removed, changed := m.Check("p1", "status", body)
-	if changed {
-		t.Error("first call should never report changed")
-	}
-	if len(added) != 0 || len(removed) != 0 {
-		t.Errorf("first call should return no diff, got added=%v removed=%v", added, removed)
+	body := []byte(`{"id":1,"state":"PRINTING","progress":5.0,"time_remaining":1800,"time_printing":60,"file":{"name":"x.gcode"}}`)
+	added, _, changed := m.Check("job", body)
+	if changed || len(added) > 0 {
+		t.Errorf("expected no change, got added=%v changed=%v", added, changed)
 	}
 }
 
-func TestAPIShapeMonitor_NoChange(t *testing.T) {
+// Regression: time_remaining appearing on a new print after a FINISHED-shaped
+// body must not alert — it's in the schema.
+func TestAPIShapeMonitor_JobTimeRemainingAppears_NoAlert(t *testing.T) {
 	m := NewAPIShapeMonitor()
-	body := []byte(`{"printer":{"state":"IDLE","temp":0}}`)
-	m.Check("p1", "status", body)
-	added, removed, changed := m.Check("p1", "status", body)
-	if changed {
-		t.Error("same JSON twice should not report changed")
-	}
-	if len(added) != 0 || len(removed) != 0 {
-		t.Errorf("expected empty diff, got added=%v removed=%v", added, removed)
+	finished := []byte(`{"id":62,"state":"FINISHED","progress":100,"time_printing":3600,"file":{"name":"x.gcode"}}`)
+	printing := []byte(`{"id":63,"state":"PRINTING","progress":5,"time_remaining":1800,"time_printing":60,"file":{"name":"y.gcode"}}`)
+	m.Check("job", finished)
+	added, _, changed := m.Check("job", printing)
+	if changed || len(added) > 0 {
+		t.Errorf("FINISHED→PRINTING transition should not alert (time_remaining is in schema), got added=%v", added)
 	}
 }
 
-func TestAPIShapeMonitor_ValueChangeNoAlert(t *testing.T) {
+// Known field disappearing is not an alert — fields may legitimately be
+// absent depending on state or firmware version.
+func TestAPIShapeMonitor_JobTimeRemainingDisappears_NoAlert(t *testing.T) {
 	m := NewAPIShapeMonitor()
-	m.Check("p1", "status", []byte(`{"printer":{"state":"IDLE"}}`))
-	added, removed, changed := m.Check("p1", "status", []byte(`{"printer":{"state":"PRINTING"}}`))
-	if changed {
-		t.Error("value-only change should not trigger shape change")
+	printing := []byte(`{"id":63,"state":"PRINTING","progress":5,"time_remaining":1800,"time_printing":60,"file":{"name":"x.gcode"}}`)
+	finished := []byte(`{"id":62,"state":"FINISHED","progress":100,"time_printing":3600,"file":{"name":"x.gcode"}}`)
+	m.Check("job", printing)
+	added, _, changed := m.Check("job", finished)
+	if changed || len(added) > 0 {
+		t.Errorf("PRINTING→FINISHED transition should not alert, got added=%v", added)
 	}
-	_ = added
-	_ = removed
 }
 
-func TestAPIShapeMonitor_AddedField(t *testing.T) {
+// /api/v1/status: job / storage / transfer / printer.axis_x / printer.axis_y
+// all legitimately come and go with state. None should alert.
+func TestAPIShapeMonitor_StatusOptionalKeys_NoAlert(t *testing.T) {
+	idle := []byte(`{"printer":{"state":"IDLE","temp_nozzle":26,"axis_x":0,"axis_y":0,"axis_z":10}}`)
+	printing := []byte(`{"job":{"id":1,"progress":5,"time_printing":60,"time_remaining":1800},"printer":{"state":"PRINTING","temp_nozzle":230,"axis_z":10}}`)
+	transfer := []byte(`{"printer":{"state":"IDLE","temp_nozzle":26},"transfer":{"id":1,"progress":50,"time_transferring":10,"transferred":512000}}`)
+	storage := []byte(`{"storage":{"path":"/usb/","name":"usb","read_only":false},"printer":{"state":"IDLE","temp_nozzle":26}}`)
+
 	m := NewAPIShapeMonitor()
-	m.Check("p1", "status", []byte(`{"printer":{"state":"IDLE"}}`))
-	added, removed, changed := m.Check("p1", "status", []byte(`{"printer":{"state":"IDLE","new_field":42}}`))
+	cycle := [][]byte{idle, printing, transfer, storage, idle, printing, transfer, storage}
+	for _, body := range cycle {
+		added, _, changed := m.Check("status", body)
+		if changed || len(added) > 0 {
+			t.Errorf("status optional keys should not alert, got added=%v", added)
+		}
+	}
+}
+
+// A genuinely unknown top-level field is the case worth alerting on.
+func TestAPIShapeMonitor_UnknownTopLevelField_Alerts(t *testing.T) {
+	m := NewAPIShapeMonitor()
+	body := []byte(`{"id":1,"state":"PRINTING","progress":5,"time_remaining":1800,"time_printing":60,"file":{"name":"x.gcode"},"material_remaining":42}`)
+	added, _, changed := m.Check("job", body)
 	if !changed {
-		t.Fatal("expected changed=true when a field is added")
-	}
-	if len(removed) != 0 {
-		t.Errorf("expected no removed fields, got %v", removed)
+		t.Fatal("expected changed=true for unknown top-level field")
 	}
 	found := false
 	for _, p := range added {
-		if p == "/printer/new_field" {
+		if p == "/material_remaining" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected /printer/new_field in added, got %v", added)
+		t.Errorf("expected /material_remaining in added, got %v", added)
 	}
 }
 
-func TestAPIShapeMonitor_RemovedField(t *testing.T) {
+// Unknown nested field is also reported.
+func TestAPIShapeMonitor_UnknownNestedField_Alerts(t *testing.T) {
 	m := NewAPIShapeMonitor()
-	m.Check("p1", "status", []byte(`{"printer":{"state":"IDLE","old_field":99}}`))
-	added, removed, changed := m.Check("p1", "status", []byte(`{"printer":{"state":"IDLE"}}`))
+	body := []byte(`{"file":{"name":"x.gcode","refs":{"download":"/x","new_ref":"y"}}}`)
+	added, _, changed := m.Check("job", body)
 	if !changed {
-		t.Fatal("expected changed=true when a field is removed")
-	}
-	if len(added) != 0 {
-		t.Errorf("expected no added fields, got %v", added)
+		t.Fatal("expected changed=true for unknown nested field")
 	}
 	found := false
-	for _, p := range removed {
-		if p == "/printer/old_field" {
+	for _, p := range added {
+		if p == "/file/refs/new_ref" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("expected /printer/old_field in removed, got %v", removed)
+		t.Errorf("expected /file/refs/new_ref in added, got %v", added)
 	}
 }
 
-func TestAPIShapeMonitor_MultiPrinterIndependent(t *testing.T) {
+// Value-only changes never alert.
+func TestAPIShapeMonitor_ValueChange_NoAlert(t *testing.T) {
 	m := NewAPIShapeMonitor()
-	base := []byte(`{"printer":{"state":"IDLE"}}`)
-	m.Check("printer-a", "status", base)
-	m.Check("printer-b", "status", base)
-
-	// Change printer-a's shape
-	added, _, changed := m.Check("printer-a", "status", []byte(`{"printer":{"state":"IDLE","extra":1}}`))
-	if !changed {
-		t.Error("printer-a should detect change")
+	m.Check("job", []byte(`{"id":1,"state":"IDLE","progress":0,"file":{"name":"x.gcode"}}`))
+	added, _, changed := m.Check("job", []byte(`{"id":1,"state":"PRINTING","progress":50,"file":{"name":"x.gcode"}}`))
+	if changed || len(added) > 0 {
+		t.Errorf("value-only change should not alert, got added=%v", added)
 	}
-	_ = added
+}
 
-	// printer-b should not be affected
-	_, _, changedB := m.Check("printer-b", "status", base)
-	if changedB {
-		t.Error("printer-b shape should be unchanged")
+// Empty body never alerts (204 No Content from /api/v1/job when idle).
+func TestAPIShapeMonitor_EmptyBody_NoAlert(t *testing.T) {
+	m := NewAPIShapeMonitor()
+	added, _, changed := m.Check("job", nil)
+	if changed || len(added) > 0 {
+		t.Errorf("empty body should not alert, got added=%v", added)
+	}
+}
+
+// Endpoint with no registered schema is silently ignored — not an alert
+// condition. (The monitor only knows status and job today.)
+func TestAPIShapeMonitor_UnknownEndpoint_NoAlert(t *testing.T) {
+	m := NewAPIShapeMonitor()
+	added, _, changed := m.Check("info", []byte(`{"hostname":"x"}`))
+	if changed || len(added) > 0 {
+		t.Errorf("unknown endpoint should not alert, got added=%v", added)
+	}
+}
+
+// Unparseable body never alerts.
+func TestAPIShapeMonitor_BadJSON_NoAlert(t *testing.T) {
+	m := NewAPIShapeMonitor()
+	added, _, changed := m.Check("job", []byte(`{not json`))
+	if changed || len(added) > 0 {
+		t.Errorf("bad JSON should not alert, got added=%v", added)
 	}
 }
 
@@ -189,7 +220,6 @@ func TestAPIShapeMonitor_Mute_SuppressesAlerts(t *testing.T) {
 	if m.ShouldAlert("p1") {
 		t.Error("should not alert while muted")
 	}
-	// Unmute via new print
 	m.UnmuteOnPrint("p1")
 	if !m.ShouldAlert("p1") {
 		t.Error("should alert again after UnmuteOnPrint")
@@ -199,84 +229,10 @@ func TestAPIShapeMonitor_Mute_SuppressesAlerts(t *testing.T) {
 func TestAPIShapeMonitor_MuteAlsoClearsPending(t *testing.T) {
 	m := NewAPIShapeMonitor()
 	m.SetAlertPending("p1")
-	m.Mute("p1") // mute should also clear pending so unmute starts fresh
+	m.Mute("p1")
 	m.UnmuteOnPrint("p1")
 	if !m.ShouldAlert("p1") {
 		t.Error("after mute+unmute, ShouldAlert should be true")
-	}
-}
-
-// ─── stripJSONKey ─────────────────────────────────────────────────────────────
-
-func TestStripJSONKey_RemovesKey(t *testing.T) {
-	body := []byte(`{"job":{"id":1},"printer":{"state":"PRINTING"}}`)
-	out := stripJSONKey(body, "job")
-	var m map[string]interface{}
-	if err := json.Unmarshal(out, &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if _, ok := m["job"]; ok {
-		t.Error("expected job key to be removed")
-	}
-	if _, ok := m["printer"]; !ok {
-		t.Error("expected printer key to remain")
-	}
-}
-
-func TestStripJSONKey_AbsentKey_Unchanged(t *testing.T) {
-	body := []byte(`{"printer":{"state":"IDLE"}}`)
-	out := stripJSONKey(body, "job")
-	var m map[string]interface{}
-	if err := json.Unmarshal(out, &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if _, ok := m["printer"]; !ok {
-		t.Error("expected printer key to remain")
-	}
-}
-
-// TestAPIShapeMonitor_StatusJobSubkeyNoFalsePositive verifies that a PRINTING→FINISHED
-// state transition (where the "job" sub-key disappears from /api/v1/status) does NOT
-// trigger a shape-change alert after normalization.
-func TestAPIShapeMonitor_StatusJobSubkeyNoFalsePositive(t *testing.T) {
-	printingBody := []byte(`{"job":{"id":62,"progress":8},"printer":{"state":"PRINTING","temp_nozzle":230}}`)
-	finishedBody := []byte(`{"printer":{"state":"FINISHED","temp_nozzle":26}}`)
-
-	m := NewAPIShapeMonitor()
-	m.Check("core-one", "status", normalizePrusaLinkStatusForMonitor(printingBody))
-	_, _, changed := m.Check("core-one", "status", normalizePrusaLinkStatusForMonitor(finishedBody))
-	if changed {
-		t.Error("job sub-key disappearing on print completion should not trigger shape change after normalization")
-	}
-}
-
-// TestAPIShapeMonitor_AxisXYDisappearsOnPrint_NoFalsePositive verifies that
-// axis_x/axis_y disappearing when a print starts (Core One L behaviour) does
-// NOT trigger a shape-change alert after normalization.
-func TestAPIShapeMonitor_AxisXYDisappearsOnPrint_NoFalsePositive(t *testing.T) {
-	idleBody  := []byte(`{"printer":{"state":"IDLE","temp_nozzle":26,"axis_x":0,"axis_y":0,"axis_z":10}}`)
-	printBody := []byte(`{"job":{"id":1,"progress":5,"time_printing":60},"printer":{"state":"PRINTING","temp_nozzle":230,"axis_z":10}}`)
-
-	m := NewAPIShapeMonitor()
-	m.Check("core-one", "status", normalizePrusaLinkStatusForMonitor(idleBody))
-	_, _, changed := m.Check("core-one", "status", normalizePrusaLinkStatusForMonitor(printBody))
-	if changed {
-		t.Error("axis_x/axis_y disappearing on print start should not trigger shape change after normalization")
-	}
-}
-
-// TestAPIShapeMonitor_TransferFieldNoFalsePositive verifies that the /transfer
-// object appearing and disappearing (present only during file uploads) does NOT
-// trigger a shape-change alert after normalization.
-func TestAPIShapeMonitor_TransferFieldNoFalsePositive(t *testing.T) {
-	idleBody     := []byte(`{"printer":{"state":"IDLE","temp_nozzle":26}}`)
-	transferBody := []byte(`{"printer":{"state":"IDLE","temp_nozzle":26},"transfer":{"id":1,"progress":50,"time_transferring":10,"transferred":512000}}`)
-
-	m := NewAPIShapeMonitor()
-	m.Check("core-one", "status", normalizePrusaLinkStatusForMonitor(idleBody))
-	_, _, changed := m.Check("core-one", "status", normalizePrusaLinkStatusForMonitor(transferBody))
-	if changed {
-		t.Error("transfer object appearing should not trigger shape change after normalization")
 	}
 }
 
@@ -288,10 +244,9 @@ func TestAPIShapeMonitor_LoadStatusFixture_Stable(t *testing.T) {
 		t.Fatalf("reading fixture: %v", err)
 	}
 	m := NewAPIShapeMonitor()
-	m.Check("core-one", "status", data)
-	_, _, changed := m.Check("core-one", "status", data)
-	if changed {
-		t.Error("same fixture twice should not report changed")
+	added, _, changed := m.Check("status", data)
+	if changed || len(added) > 0 {
+		t.Errorf("status fixture should match schema, got added=%v", added)
 	}
 }
 
@@ -301,9 +256,8 @@ func TestAPIShapeMonitor_LoadJobFixture_Stable(t *testing.T) {
 		t.Fatalf("reading fixture: %v", err)
 	}
 	m := NewAPIShapeMonitor()
-	m.Check("core-one", "job", data)
-	_, _, changed := m.Check("core-one", "job", data)
-	if changed {
-		t.Error("same fixture twice should not report changed")
+	added, _, changed := m.Check("job", data)
+	if changed || len(added) > 0 {
+		t.Errorf("job fixture should match schema, got added=%v", added)
 	}
 }

--- a/bridge.go
+++ b/bridge.go
@@ -66,24 +66,24 @@ func prettyJSON(raw []byte) string {
 
 // FilamentBridge manages the connection between PrusaLink and Spoolman
 type FilamentBridge struct {
-	config           *Config
-	spoolman         *SpoolmanClient
-	db               *sql.DB
-	wasPrinting      map[string]bool
-	currentJobFile   map[string]string     // Store current job filename per printer
-	currentJobDisplayName map[string]string // Display name (long filename) for current job
-	currentJobID     map[string]int        // Job ID from PRINTING state; carried to finish handler
-	processingPrints map[string]bool       // Track prints being processed
-	monitoringActive map[string]bool       // Guard against overlapping monitor goroutines per printer
-	printErrors      map[string]PrintError // Store print processing errors
-	errorMutex       sync.RWMutex
-	previousState    map[string]string    // Last seen printer state per printer
-	printStartTime   map[string]time.Time // When each printer's current job was first detected
-	mutex            sync.RWMutex
+	config                *Config
+	spoolman              *SpoolmanClient
+	db                    *sql.DB
+	wasPrinting           map[string]bool
+	currentJobFile        map[string]string     // Store current job filename per printer
+	currentJobDisplayName map[string]string     // Display name (long filename) for current job
+	currentJobID          map[string]int        // Job ID from PRINTING state; carried to finish handler
+	processingPrints      map[string]bool       // Track prints being processed
+	monitoringActive      map[string]bool       // Guard against overlapping monitor goroutines per printer
+	printErrors           map[string]PrintError // Store print processing errors
+	errorMutex            sync.RWMutex
+	previousState         map[string]string    // Last seen printer state per printer
+	printStartTime        map[string]time.Time // When each printer's current job was first detected
+	mutex                 sync.RWMutex
 
 	// Bambu MQTT clients — long-lived, one per printer, keyed by printerID
-	bambuClients      map[string]BambuStatusProvider
-	bambuMutex        sync.RWMutex
+	bambuClients map[string]BambuStatusProvider
+	bambuMutex   sync.RWMutex
 	// bambuClientFactory creates a new Bambu client; overridable in tests.
 	bambuClientFactory func(ip, serial, accessCode string) BambuStatusProvider
 
@@ -224,8 +224,8 @@ type PrintQualityTag struct {
 
 // PrintTagsPayload is the body for POST /api/history/:id/tags.
 type PrintTagsPayload struct {
-	Outcome    string   `json:"outcome"`    // "success" | "acceptable" | "failed" | ""
-	Issues     []string `json:"issues"`     // predefined and/or "custom"
+	Outcome    string   `json:"outcome"` // "success" | "acceptable" | "failed" | ""
+	Issues     []string `json:"issues"`  // predefined and/or "custom"
 	CustomText string   `json:"custom_text"`
 }
 
@@ -357,23 +357,23 @@ type PrinterData struct {
 // NewFilamentBridge creates a new FilamentBridge instance
 func NewFilamentBridge(config *Config) (*FilamentBridge, error) {
 	bridge := &FilamentBridge{
-		config:           config,
-		spoolman:         NewSpoolmanClient(DefaultSpoolmanURL, SpoolmanTimeout),
+		config:                config,
+		spoolman:              NewSpoolmanClient(DefaultSpoolmanURL, SpoolmanTimeout),
 		wasPrinting:           make(map[string]bool),
 		currentJobFile:        make(map[string]string),
 		currentJobDisplayName: make(map[string]string),
 		currentJobID:          make(map[string]int),
 		processingPrints:      make(map[string]bool),
-		monitoringActive: make(map[string]bool),
-		printErrors:      make(map[string]PrintError),
-		previousState:    make(map[string]string),
-		printStartTime:   make(map[string]time.Time),
-		bambuClients:     make(map[string]BambuStatusProvider),
-		lastSnapshotPct:  make(map[string]float64),
-		commLogs:         make(map[string]*PrinterCommLog),
-		rawResponses:     make(map[string]*PrusaLinkRawCapture),
-		apiMonitor:       NewAPIShapeMonitor(),
-		printerWarnings:  make(map[string][]PrinterWarning),
+		monitoringActive:      make(map[string]bool),
+		printErrors:           make(map[string]PrintError),
+		previousState:         make(map[string]string),
+		printStartTime:        make(map[string]time.Time),
+		bambuClients:          make(map[string]BambuStatusProvider),
+		lastSnapshotPct:       make(map[string]float64),
+		commLogs:              make(map[string]*PrinterCommLog),
+		rawResponses:          make(map[string]*PrusaLinkRawCapture),
+		apiMonitor:            NewAPIShapeMonitor(),
+		printerWarnings:       make(map[string][]PrinterWarning),
 	}
 	bridge.bambuClientFactory = func(ip, serial, accessCode string) BambuStatusProvider {
 		return NewBambuMQTTClient(ip, serial, accessCode, newBambuDebugLogger(bridge))
@@ -2342,19 +2342,19 @@ func (b *FilamentBridge) migrateToolheadMappingsToSpoolman() error {
 // initializeDefaultConfig sets up default configuration values
 func (b *FilamentBridge) initializeDefaultConfig() error {
 	defaultConfigs := map[string]string{
-		ConfigKeyPrinterIPs:                      "", // Comma-separated list of printer IP addresses
-		ConfigKeyAPIKey:                          "", // PrusaLink API key for authentication
-		ConfigKeySpoolmanURL:                     DefaultSpoolmanURL,
-		ConfigKeyPollInterval:                    fmt.Sprintf("%d", DefaultPollInterval),
-		ConfigKeyWebPort:                         DefaultWebPort,
-		ConfigKeyPrusaLinkTimeout:                fmt.Sprintf("%d", PrusaLinkTimeout),
-		ConfigKeyPrusaLinkFileDownloadTimeout:    fmt.Sprintf("%d", PrusaLinkFileDownloadTimeout),
-		ConfigKeySpoolmanTimeout:                 fmt.Sprintf("%d", SpoolmanTimeout),
-		ConfigKeyAutoAssignPreviousSpoolEnabled: "false", // Enable auto-assignment of previous spool to default location
-		ConfigKeyNFCTrashLocation:                "Trash",     // Location for empty/done spools (tag ready to re-program)
-		ConfigKeyNFCInventoryLocation:            "Inventory", // Default storage when spool displaced from toolhead
-		ConfigKeySpoolmanLocationSyncEnabled:     "false",     // Bidirectional Spoolman location sync
-		ConfigKeyNFCTapTimeoutSeconds:            "15",        // Tap-tap pending window in seconds (Stage 5)
+		ConfigKeyPrinterIPs:                     "", // Comma-separated list of printer IP addresses
+		ConfigKeyAPIKey:                         "", // PrusaLink API key for authentication
+		ConfigKeySpoolmanURL:                    DefaultSpoolmanURL,
+		ConfigKeyPollInterval:                   fmt.Sprintf("%d", DefaultPollInterval),
+		ConfigKeyWebPort:                        DefaultWebPort,
+		ConfigKeyPrusaLinkTimeout:               fmt.Sprintf("%d", PrusaLinkTimeout),
+		ConfigKeyPrusaLinkFileDownloadTimeout:   fmt.Sprintf("%d", PrusaLinkFileDownloadTimeout),
+		ConfigKeySpoolmanTimeout:                fmt.Sprintf("%d", SpoolmanTimeout),
+		ConfigKeyAutoAssignPreviousSpoolEnabled: "false",     // Enable auto-assignment of previous spool to default location
+		ConfigKeyNFCTrashLocation:               "Trash",     // Location for empty/done spools (tag ready to re-program)
+		ConfigKeyNFCInventoryLocation:           "Inventory", // Default storage when spool displaced from toolhead
+		ConfigKeySpoolmanLocationSyncEnabled:    "false",     // Bidirectional Spoolman location sync
+		ConfigKeyNFCTapTimeoutSeconds:           "15",        // Tap-tap pending window in seconds (Stage 5)
 	}
 
 	// INSERT OR IGNORE ensures new keys added in updates are seeded for existing
@@ -2375,19 +2375,19 @@ func (b *FilamentBridge) initializeDefaultConfig() error {
 // getConfigDescription returns a description for a configuration key
 func getConfigDescription(key string) string {
 	descriptions := map[string]string{
-		ConfigKeyPrinterIPs:                      "Comma-separated list of printer IP addresses for PrusaLink",
-		ConfigKeyAPIKey:                          "PrusaLink API key for authentication",
-		ConfigKeySpoolmanURL:                     "URL of Spoolman instance",
-		ConfigKeyPollInterval:                    "Polling interval in seconds",
-		ConfigKeyWebPort:                         "Port for web interface",
-		ConfigKeyPrusaLinkTimeout:                "PrusaLink API timeout in seconds",
-		ConfigKeyPrusaLinkFileDownloadTimeout:    "PrusaLink file download header timeout in seconds (body reading is unbounded to support large bgcode files)",
-		ConfigKeySpoolmanTimeout:                 "Spoolman API timeout in seconds",
+		ConfigKeyPrinterIPs:                     "Comma-separated list of printer IP addresses for PrusaLink",
+		ConfigKeyAPIKey:                         "PrusaLink API key for authentication",
+		ConfigKeySpoolmanURL:                    "URL of Spoolman instance",
+		ConfigKeyPollInterval:                   "Polling interval in seconds",
+		ConfigKeyWebPort:                        "Port for web interface",
+		ConfigKeyPrusaLinkTimeout:               "PrusaLink API timeout in seconds",
+		ConfigKeyPrusaLinkFileDownloadTimeout:   "PrusaLink file download header timeout in seconds (body reading is unbounded to support large bgcode files)",
+		ConfigKeySpoolmanTimeout:                "Spoolman API timeout in seconds",
 		ConfigKeyAutoAssignPreviousSpoolEnabled: "Enable automatic assignment of previous spool to Inventory location when assigning new spool to toolhead",
-		ConfigKeyNFCTrashLocation:                "Spoolman location name for empty/finished spools (NFC tag ready to re-program)",
-		ConfigKeyNFCInventoryLocation:            "Spoolman location name used as default storage when a spool is displaced from a toolhead via NFC",
-		ConfigKeySpoolmanLocationSyncEnabled:     "When true, The Moment writes spool locations to Spoolman on assign/unassign and polls for Spoolman-initiated moves",
-		ConfigKeyNFCTapTimeoutSeconds:            "Seconds a first NFC tap stays pending before a second tap is treated as a fresh first tap (tap-tap engine)",
+		ConfigKeyNFCTrashLocation:               "Spoolman location name for empty/finished spools (NFC tag ready to re-program)",
+		ConfigKeyNFCInventoryLocation:           "Spoolman location name used as default storage when a spool is displaced from a toolhead via NFC",
+		ConfigKeySpoolmanLocationSyncEnabled:    "When true, The Moment writes spool locations to Spoolman on assign/unassign and polls for Spoolman-initiated moves",
+		ConfigKeyNFCTapTimeoutSeconds:           "Seconds a first NFC tap stays pending before a second tap is treated as a fresh first tap (tap-tap engine)",
 	}
 	if desc, exists := descriptions[key]; exists {
 		return desc
@@ -2458,7 +2458,6 @@ func (b *FilamentBridge) SetAutoAssignPreviousSpoolEnabled(enabled bool) error {
 	}
 	return b.SetConfigValue(ConfigKeyAutoAssignPreviousSpoolEnabled, value)
 }
-
 
 // GetAllPrinterConfigs gets all printer configurations
 func (b *FilamentBridge) GetAllPrinterConfigs() (map[string]PrinterConfig, error) {
@@ -3295,6 +3294,7 @@ func (b *FilamentBridge) MonitorPrinters() {
 // State machine:
 //
 //	PRINTING          → track wasPrinting=true, store job filename
+//
 // checkFilamentSufficiency estimates the filament required for the active job and compares it
 // against the remaining weight on each assigned spool. Intended to be called in a goroutine
 // at print-start so it never blocks the monitor loop.
@@ -3428,10 +3428,10 @@ func (b *FilamentBridge) checkFilamentSufficiency(printerID, printerName, filePa
 	b.printerWarningsMu.Unlock()
 }
 
-//	PAUSED            → keep wasPrinting=true (print will resume)
-//	ATTENTION         → keep wasPrinting=true (filament runout — user swaps spool, then resumes)
-//	IDLE / FINISHED   → if wasPrinting: print completed normally → process full G-code usage
-//	STOPPED           → if wasPrinting: job was cancelled → log partial usage from progress %
+// PAUSED            → keep wasPrinting=true (print will resume)
+// ATTENTION         → keep wasPrinting=true (filament runout — user swaps spool, then resumes)
+// IDLE / FINISHED   → if wasPrinting: print completed normally → process full G-code usage
+// STOPPED           → if wasPrinting: job was cancelled → log partial usage from progress %
 func (b *FilamentBridge) monitorPrusaLink(printerID string, config PrinterConfig) error {
 	client := NewPrusaLinkClient(config.IPAddress, config.APIKey, b.config.PrusaLinkTimeout, b.config.PrusaLinkFileDownloadTimeout)
 	cl := b.getCommLog(printerID)
@@ -3472,21 +3472,21 @@ func (b *FilamentBridge) monitorPrusaLink(printerID string, config PrinterConfig
 	}
 	b.rawResponsesMu.Unlock()
 
-	// Detect API shape changes (e.g. unknown objects received from PrusaLink).
-	// The "job" sub-object in /api/v1/status is state-dependent: present during printing,
-	// absent when idle/finished. Strip it before shape comparison so a print completing
-	// doesn't trigger a false-positive "removed fields" alert.
+	// Detect API shape changes (e.g. unknown top-level fields received from PrusaLink).
+	// The monitor diffs each body against a per-endpoint schema of known field paths, so
+	// state-dependent fields (time_remaining on FINISHED, axis_x/y during PRINTING, the
+	// transfer sub-object during uploads, etc.) do not raise false positives.
 	for _, check := range []struct {
 		endpoint string
 		body     []byte
 	}{
-		{"status", normalizePrusaLinkStatusForMonitor(statusRaw)},
+		{"status", statusRaw},
 		{"job", jobRaw},
 	} {
 		if len(check.body) == 0 {
 			continue
 		}
-		added, removed, changed := b.apiMonitor.Check(printerID, check.endpoint, check.body)
+		added, removed, changed := b.apiMonitor.Check(check.endpoint, check.body)
 		if changed {
 			diff := FormatDiff("/api/v1/"+check.endpoint, added, removed)
 			cl.Append("EV", "api_change", diff, "")
@@ -6748,48 +6748,6 @@ func (b *FilamentBridge) GetDashboardStats() (*DashboardStats, error) {
 		WHERE ph.status = 'completed' AND julianday(ph.print_finished) >= julianday('now', '-30 days')`).Scan(&s.TotalCost30d, &s.Currency)
 	b.db.QueryRow(`SELECT COALESCE(AVG(print_time_minutes), 0) FROM print_history WHERE status = 'completed' AND print_time_minutes > 0 AND julianday(print_finished) >= julianday('now', '-30 days')`).Scan(&s.AvgPrintTimeMin)
 	return s, nil
-}
-
-// stripJSONKey removes one top-level key from a JSON object body.
-// Returns the original body unchanged on any parse error.
-func stripJSONKey(body []byte, key string) []byte {
-	var m map[string]interface{}
-	if err := json.Unmarshal(body, &m); err != nil {
-		return body
-	}
-	delete(m, key)
-	out, err := json.Marshal(m)
-	if err != nil {
-		return body
-	}
-	return out
-}
-
-// normalizePrusaLinkStatusForMonitor removes fields that are conditionally
-// present depending on printer state so the shape monitor only fires on
-// genuine structural changes, not idle↔printing transitions.
-//
-// Stripped fields:
-//   - "job": absent when idle, present when printing
-//   - "storage": optional/variable across firmware versions
-//   - printer.axis_x, printer.axis_y: present when idle, absent during printing
-func normalizePrusaLinkStatusForMonitor(body []byte) []byte {
-	var m map[string]interface{}
-	if err := json.Unmarshal(body, &m); err != nil {
-		return body
-	}
-	delete(m, "job")
-	delete(m, "storage")
-	delete(m, "transfer")
-	if printer, ok := m["printer"].(map[string]interface{}); ok {
-		delete(printer, "axis_x")
-		delete(printer, "axis_y")
-	}
-	out, err := json.Marshal(m)
-	if err != nil {
-		return body
-	}
-	return out
 }
 
 // All The Moment location management functions have been removed - locations are now managed in Spoolman only


### PR DESCRIPTION
Fixes #1 

Tested locally with a Prusa CoreOne running FW v6.5.3.

## Summary
The `APIShapeMonitor` diffed each `/api/v1/job` response against the *first body it ever saw* for a given printer.
On PrusaLink, `time_remaining` is only present while `PRINTING`/`PAUSED`, not in `FINISHED`/`STOPPED`. A first poll of a finished job therefore locked in a partial baseline, and the next print raised a spurious "new fields in /api/v1/job: /time_remaining" alert, which `bridge.monitorPrusaLink` reported as a print failure — even though Spoolman was being updated correctly. `PrusaLinkJob` already declared `time_remaining`; only the monitor was wrong.

## Fix
Replace the "first body" baseline with a fixed per-endpoint schema (`statusSchema`, `jobSchema` in `api_monitor.go`) listing the field paths the structs declare plus the state-/lifecycle-dependent keys the API may or may not emit (`job`, `storage`, `transfer`, `printer.axis_x/y`, `filament`, `time_remaining`).
The monitor now reports only fields it has never seen in the schema — a genuine unknown addition from a firmware change still fires.
`removed` field detection and the per-printer body baseline are gone.
The `normalizePrusaLinkStatusForMonitor` / `stripJSONKey` band-aids in
`bridge.go` are no longer needed and are removed; the call site passes the raw bodies directly.

## Notes
After some digging around in the specifics of the PrusaLink API, there seems to be an [openapi file](https://github.com/prusa3d/Prusa-Link-Web/blob/master/spec/openapi.yaml) which could maybe be integrated here for better parsing and validation of the API resources in the future.