### PR TITLE
Add Spoolman External URL

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -468,6 +468,10 @@ func NewFilamentBridge(config *Config) (*FilamentBridge, error) {
 		return nil, fmt.Errorf("failed to migrate OpenPrintTag sources: %w", err)
 	}
 
+	if err := bridge.migrateSpoolmanExternalURL(); err != nil {
+		log.Printf("Warning: failed to migrate Spoolman external URL: %v", err)
+	}
+
 	if err := bridge.deduplicateRecoveryStubs(); err != nil {
 		log.Printf("[RECONCILE] dedup migration warning: %v", err)
 	}
@@ -2339,12 +2343,27 @@ func (b *FilamentBridge) migrateToolheadMappingsToSpoolman() error {
 	return nil
 }
 
+// migrateSpoolmanExternalURL seeds spoolman_external_url from spoolman_url for
+// existing single-URL deployments. INSERT OR IGNORE means fresh installs that
+// already have the key in initializeDefaultConfig are unaffected.
+func (b *FilamentBridge) migrateSpoolmanExternalURL() error {
+	_, err := b.db.Exec(
+		`INSERT OR IGNORE INTO configuration (key, value) SELECT ?, value FROM configuration WHERE key = ?`,
+		ConfigKeySpoolmanExternalURL, ConfigKeySpoolmanURL,
+	)
+	if err != nil {
+		return fmt.Errorf("seed spoolman_external_url: %w", err)
+	}
+	return nil
+}
+
 // initializeDefaultConfig sets up default configuration values
 func (b *FilamentBridge) initializeDefaultConfig() error {
 	defaultConfigs := map[string]string{
 		ConfigKeyPrinterIPs:                     "", // Comma-separated list of printer IP addresses
 		ConfigKeyAPIKey:                         "", // PrusaLink API key for authentication
 		ConfigKeySpoolmanURL:                    DefaultSpoolmanURL,
+		ConfigKeySpoolmanExternalURL:            DefaultSpoolmanExternalURL,
 		ConfigKeyPollInterval:                   fmt.Sprintf("%d", DefaultPollInterval),
 		ConfigKeyWebPort:                        DefaultWebPort,
 		ConfigKeyPrusaLinkTimeout:               fmt.Sprintf("%d", PrusaLinkTimeout),
@@ -2377,7 +2396,8 @@ func getConfigDescription(key string) string {
 	descriptions := map[string]string{
 		ConfigKeyPrinterIPs:                     "Comma-separated list of printer IP addresses for PrusaLink",
 		ConfigKeyAPIKey:                         "PrusaLink API key for authentication",
-		ConfigKeySpoolmanURL:                    "URL of Spoolman instance",
+		ConfigKeySpoolmanURL:                    "URL of Spoolman instance (internal — used for API calls)",
+		ConfigKeySpoolmanExternalURL:            "URL of Spoolman instance reachable from the user's browser (used for UI links; falls back to spoolman_url when empty)",
 		ConfigKeyPollInterval:                   "Polling interval in seconds",
 		ConfigKeyWebPort:                        "Port for web interface",
 		ConfigKeyPrusaLinkTimeout:               "PrusaLink API timeout in seconds",
@@ -2884,6 +2904,21 @@ func (b *FilamentBridge) pushSpoolToInventory(spoolID int) {
 	}
 }
 
+// GetSpoolmanExternalURL returns the browser-reachable Spoolman URL. Falls back to
+// the internal URL when the external one is not set, so existing single-URL
+// deployments keep working.
+func (b *FilamentBridge) GetSpoolmanExternalURL() string {
+	b.mutex.RLock()
+	defer b.mutex.RUnlock()
+	if b.config == nil {
+		return ""
+	}
+	if b.config.SpoolmanExternalURL != "" {
+		return b.config.SpoolmanExternalURL
+	}
+	return b.config.SpoolmanURL
+}
+
 // GetConfigSnapshot returns a snapshot of the current config for safe iteration
 func (b *FilamentBridge) GetConfigSnapshot() *Config {
 	b.mutex.RLock()
@@ -2897,6 +2932,7 @@ func (b *FilamentBridge) GetConfigSnapshot() *Config {
 	// Create a shallow copy of the config
 	configCopy := &Config{
 		SpoolmanURL:                  b.config.SpoolmanURL,
+		SpoolmanExternalURL:          b.config.SpoolmanExternalURL,
 		PollInterval:                 b.config.PollInterval,
 		DBFile:                       b.config.DBFile,
 		GcodePath:                    b.config.GcodePath,

--- a/config.go
+++ b/config.go
@@ -52,6 +52,7 @@ type FilamentSpool struct {
 // Config holds all configuration for the application
 type Config struct {
 	SpoolmanURL                  string
+	SpoolmanExternalURL          string
 	PollInterval                 time.Duration
 	LocationSyncInterval         time.Duration
 	DBFile                       string
@@ -112,6 +113,7 @@ func LoadConfig(bridge *FilamentBridge) (*Config, error) {
 
 	config := &Config{
 		SpoolmanURL:                  configValues[ConfigKeySpoolmanURL],
+		SpoolmanExternalURL:          configValues[ConfigKeySpoolmanExternalURL],
 		PollInterval:                 time.Duration(pollInterval) * time.Second,
 		LocationSyncInterval:         time.Duration(locationSyncInterval) * time.Minute,
 		DBFile:                       getDBFilePath(),

--- a/constants.go
+++ b/constants.go
@@ -21,6 +21,7 @@ const (
 // Default configuration values
 const (
 	DefaultSpoolmanURL          = "http://localhost:7912"
+	DefaultSpoolmanExternalURL  = "http://localhost:7912"
 	DefaultWebPort              = "5000"
 	DefaultPollInterval         = 30
 	DefaultLocationSyncInterval = 5 // minutes
@@ -32,6 +33,7 @@ const (
 	ConfigKeyPrinterIPs                      = "printer_ips"
 	ConfigKeyAPIKey                          = "prusalink_api_key"
 	ConfigKeySpoolmanURL                     = "spoolman_url"
+	ConfigKeySpoolmanExternalURL            = "spoolman_external_url"
 	ConfigKeyPollInterval                    = "poll_interval"
 	ConfigKeyLocationSyncInterval            = "location_sync_interval"
 	ConfigKeyWebPort                         = "web_port"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       # This env var is read at first-run config init; if you have already run
       # The Moment and configured it via the UI, this variable is ignored.
       SPOOLMAN_URL: http://spoolman:8000
+      # Browser-reachable Spoolman URL. Used for "Open Spoolman" links in the UI.
+      SPOOLMAN_EXTERNAL_URL: ${SPOOLMAN_EXTERNAL_URL:-http://spoolman:8000}
     networks:
       - momentnet
     healthcheck:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -282,6 +282,7 @@ In Docker, host paths set in `.env` are bind-mounted into the container at the f
 | Variable | Read by | Default | Purpose |
 |---|---|---|---|
 | `SPOOLMAN_URL` | `main.go` (first-run seed only) | `http://localhost:7912` | URL The Moment uses to reach Spoolman. Only applied when the database is first created; ignored on subsequent starts. In Docker compose this is set to `http://spoolman:8000` (Docker DNS). Change via Settings → Advanced after first run. |
+| `SPOOLMAN_EXTERNAL_URL` | `main.go` (first-run seed only) | `http://localhost:7912` | Browser-reachable Spoolman URL. Used for "Open Spoolman" links in the UI. In Docker compose this defaults to `http://spoolman:8000`. Falls back to `SPOOLMAN_URL` when empty. |
 | `BAMBU_DEBUG` | `bambu.go` | `0` | Set to `1` for verbose Bambu MQTT debug logging (requires restart). Hot-togglable without restart via Settings → Advanced → `bambu_debug = true`. |
 
 ### Backup

--- a/main.go
+++ b/main.go
@@ -66,6 +66,20 @@ func main() {
 		log.Printf("Spoolman URL set from SPOOLMAN_URL env var: %s", envSpoolman)
 	}
 
+	// Override Spoolman external URL from env var (defaults to SPOOLMAN_URL or the
+	// stored value). Lets docker compose / k8s manifests set the browser-reachable
+	// address independently of the internal one.
+	if envExt := os.Getenv("SPOOLMAN_EXTERNAL_URL"); envExt != "" && config.SpoolmanExternalURL == DefaultSpoolmanExternalURL {
+		config.SpoolmanExternalURL = envExt
+		if err := bridge.SetConfigValue(ConfigKeySpoolmanExternalURL, envExt); err != nil {
+			log.Printf("Warning: could not persist SPOOLMAN_EXTERNAL_URL env override: %v", err)
+		}
+		if err := bridge.UpdateConfig(config); err != nil {
+			log.Printf("Warning: could not apply SPOOLMAN_EXTERNAL_URL env override to bridge: %v", err)
+		}
+		log.Printf("Spoolman external URL set from SPOOLMAN_EXTERNAL_URL env var: %s", envExt)
+	}
+
 	// Handle graceful shutdown
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)

--- a/nfc_management.go
+++ b/nfc_management.go
@@ -574,7 +574,7 @@ func (ws *WebServer) nfcTagResolveHandler(c *gin.Context) {
 		return
 	}
 
-	spoolmanURL := ws.bridge.config.SpoolmanURL
+	spoolmanURL := ws.bridge.GetSpoolmanExternalURL()
 
 	switch result.Action {
 	case TapUnknown:
@@ -637,7 +637,7 @@ func (ws *WebServer) buildPendingPageData(tag *NFCTag, result TapResult, host st
 		"Action":      result.Action,
 		"TagType":     tag.TagType,
 		"TagURL":      nfcTagURL(host, tag.TagID),
-		"SpoolmanURL": ws.bridge.config.SpoolmanURL,
+		"SpoolmanURL": ws.bridge.GetSpoolmanExternalURL(),
 	}
 	if tag.Label != nil {
 		data["Label"] = *tag.Label
@@ -713,7 +713,7 @@ func (ws *WebServer) nfcTagTapPostHandler(c *gin.Context) {
 		"FilamentID":   result.FilamentID,
 		"FilamentName": result.FilamentName,
 		"Message":      result.Message,
-		"SpoolmanURL":  ws.bridge.config.SpoolmanURL,
+		"SpoolmanURL":  ws.bridge.GetSpoolmanExternalURL(),
 	})
 }
 

--- a/spoolman_external_url_test.go
+++ b/spoolman_external_url_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// The Moment — derived from FilaBridge (https://github.com/needo37/filabridge)
+// Copyright (C) 2026 maudy2u
+
+package main
+
+import "testing"
+
+// TestGetSpoolmanExternalURL_FallsBackToInternal verifies the helper returns the
+// internal URL when the external one is empty (single-URL deployments).
+func TestGetSpoolmanExternalURL_FallsBackToInternal(t *testing.T) {
+	b := &FilamentBridge{
+		config: &Config{
+			SpoolmanURL:         "http://spoolman:8000",
+			SpoolmanExternalURL: "",
+		},
+	}
+	if got := b.GetSpoolmanExternalURL(); got != "http://spoolman:8000" {
+		t.Errorf("expected fallback to internal URL, got %q", got)
+	}
+}
+
+// TestGetSpoolmanExternalURL_PrefersExternal verifies the helper returns the
+// external URL when both are set (Docker/k8s deploy with separate external host).
+func TestGetSpoolmanExternalURL_PrefersExternal(t *testing.T) {
+	b := &FilamentBridge{
+		config: &Config{
+			SpoolmanURL:         "http://spoolman:8000",
+			SpoolmanExternalURL: "http://nas.local:7912",
+		},
+	}
+	if got := b.GetSpoolmanExternalURL(); got != "http://nas.local:7912" {
+		t.Errorf("expected external URL, got %q", got)
+	}
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -134,9 +134,14 @@ function loadConfiguration() {
             form.innerHTML = `
                 <div style="max-width: 600px; margin: 0 auto;">
                     <div class="form-group">
-                        <label><strong>Spoolman URL:</strong></label>
-                        <input type="text" id="spoolman_url" value="${config.spoolman_url || ''}" placeholder="http://localhost:8000">
-                        <small>URL where Spoolman is running</small>
+                        <label><strong>Spoolman URL (internal):</strong></label>
+                        <input type="text" id="spoolman_url" value="${config.spoolman_url || ''}" placeholder="http://spoolman:8000">
+                        <small>URL The Moment uses to call the Spoolman API. Use a hostname reachable from this container (e.g. <code>http://spoolman:8000</code> in Docker, <code>http://localhost:7912</code> on bare metal).</small>
+                    </div>
+                    <div class="form-group">
+                        <label><strong>Spoolman URL (external / browser):</strong></label>
+                        <input type="text" id="spoolman_external_url" value="${config.spoolman_external_url || ''}" placeholder="http://your-host:7912">
+                        <small>URL the user's browser should use for "Open Spoolman" links. Leave blank to fall back to the internal URL above.</small>
                     </div>
                     <div class="form-group">
                         <label><strong>Poll Interval (seconds):</strong></label>
@@ -160,6 +165,7 @@ function loadConfiguration() {
 function saveConfiguration() {
     const config = {
         spoolman_url: document.getElementById('spoolman_url').value,
+        spoolman_external_url: document.getElementById('spoolman_external_url').value,
         poll_interval: document.getElementById('poll_interval').value
     };
 
@@ -183,8 +189,12 @@ function saveConfiguration() {
 }
 
 function testSpoolmanURL() {
-    const url = document.getElementById('spoolman_url').value.trim();
     const resultEl = document.getElementById('spoolman-test-result');
+    const active = document.activeElement && document.activeElement.id;
+    const urlEl = (active === 'spoolman_external_url')
+        ? document.getElementById('spoolman_external_url')
+        : document.getElementById('spoolman_url');
+    const url = urlEl.value.trim();
 
     if (!url) {
         resultEl.style.color = '#f0a500';

--- a/static/js/nfc.js
+++ b/static/js/nfc.js
@@ -64,7 +64,7 @@ async function loadLocationTags() {
         container.innerHTML = '';
 
         // Add informational banner about Spoolman locations
-        const spoolmanURL = data.spoolman_url || '';
+        const spoolmanURL = data.spoolman_external_url || data.spoolman_url || '';
         const messageBanner = document.createElement('div');
         messageBanner.className = 'nfc-info-banner';
         messageBanner.style.cssText = 'background: #fff3cd; border: 1px solid #ffeaa7; color: #856404; padding: 15px; margin-bottom: 15px; border-radius: 8px;';

--- a/static/js/printers.js
+++ b/static/js/printers.js
@@ -55,8 +55,8 @@ function loadEditPrinterToolheadsTab() {
         }
 
         var link = document.getElementById('editPrinterSpoolmanLink');
-        if (link && spoolmanData.spoolman_url) {
-            link.href = spoolmanData.spoolman_url;
+        if (link && spoolmanData.spoolman_external_url) {
+            link.href = spoolmanData.spoolman_external_url;
         }
 
         var toolheadCount = printerData.toolheads || 1;

--- a/web.go
+++ b/web.go
@@ -557,7 +557,7 @@ func (ws *WebServer) dashboardHandler(c *gin.Context) {
 		"Printers":          ws.bridge.config.Printers,
 		"SpoolmanConnected": spoolmanConnected,
 		"SpoolmanError":     spoolmanError,
-		"SpoolmanBaseURL":   ws.bridge.config.SpoolmanURL,
+		"SpoolmanBaseURL":   ws.bridge.GetSpoolmanExternalURL(),
 		"AppVersion":        AppVersion,
 	})
 }
@@ -1404,8 +1404,8 @@ func (ws *WebServer) spoolmanLocationsHandler(c *gin.Context) {
 		}
 	}
 	c.JSON(http.StatusOK, gin.H{
-		"locations":    names,
-		"spoolman_url": ws.bridge.spoolman.GetBaseURL(),
+		"locations":             names,
+		"spoolman_external_url": ws.bridge.GetSpoolmanExternalURL(),
 	})
 }
 
@@ -2933,11 +2933,11 @@ func (ws *WebServer) nfcUrlsHandler(c *gin.Context) {
 	})
 
 	// Get Spoolman URL for the response
-	spoolmanURL := ws.bridge.spoolman.GetBaseURL()
+	spoolmanURL := ws.bridge.GetSpoolmanExternalURL()
 
 	c.JSON(http.StatusOK, gin.H{
-		"urls":         urls,
-		"spoolman_url": spoolmanURL,
+		"urls":                  urls,
+		"spoolman_external_url": spoolmanURL,
 	})
 }
 
@@ -3000,11 +3000,11 @@ func (ws *WebServer) getLocationsHandler(c *gin.Context) {
 	}
 
 	// Get Spoolman URL for the message
-	spoolmanURL := ws.bridge.spoolman.GetBaseURL()
+	spoolmanURL := ws.bridge.GetSpoolmanExternalURL()
 
 	c.JSON(http.StatusOK, gin.H{
-		"locations":    allLocations,
-		"spoolman_url": spoolmanURL,
+		"locations":             allLocations,
+		"spoolman_external_url": spoolmanURL,
 	})
 }
 


### PR DESCRIPTION
In Docker / k8s deployment, the hostname the server uses to reach Spoolman (http://spoolman:8000 on the internal network) is not the same one a user's browser can reach (http://nas.local:7912 or whatever their reverse proxy exposes).

This PR splits the single `spoolman_url` setting into `spoolman_url` (internal, for API calls) and `spoolman_external_url` (browser-reachable, for UI links), with the external field falling back to the internal one when empty.