### PR TITLE
Add /job/filament_change_in to API schema and tests

### DIFF
--- a/api_monitor.go
+++ b/api_monitor.go
@@ -54,6 +54,7 @@ func NewAPIShapeMonitor() *APIShapeMonitor {
 //   - job: present while printing, absent when idle/finished
 //   - transfer: present only during file uploads
 //   - printer.axis_x / axis_y: present when idle, absent while printing (Core One L)
+//   - job.filament_change_in: present when a scheduled filament change is pending
 func statusSchema() map[string]bool {
 	return map[string]bool{
 		"/job":                        true,
@@ -61,6 +62,7 @@ func statusSchema() map[string]bool {
 		"/job/progress":               true,
 		"/job/time_remaining":         true,
 		"/job/time_printing":          true,
+		"/job/filament_change_in":     true,
 		"/storage":                    true,
 		"/storage/path":               true,
 		"/storage/name":               true,

--- a/api_monitor_test.go
+++ b/api_monitor_test.go
@@ -121,6 +121,21 @@ func TestAPIShapeMonitor_StatusOptionalKeys_NoAlert(t *testing.T) {
 	}
 }
 
+// Scheduled filament change field should not alert — it's optional and in the schema.
+func TestAPIShapeMonitor_FilamentChangeIn_NoAlert(t *testing.T) {
+	m := NewAPIShapeMonitor()
+	// Printing without scheduled filament change
+	without := []byte(`{"job":{"id":1,"progress":26,"time_remaining":3720,"time_printing":1626},"printer":{"state":"PRINTING","temp_nozzle":249.9}}`)
+	// Printing with scheduled filament change
+	with := []byte(`{"job":{"id":1,"progress":26,"time_remaining":3720,"filament_change_in":2940,"time_printing":1626},"printer":{"state":"PRINTING","temp_nozzle":249.9}}`)
+
+	m.Check("status", without)
+	added, _, changed := m.Check("status", with)
+	if changed || len(added) > 0 {
+		t.Errorf("filament_change_in field should not alert (is in schema), got added=%v", added)
+	}
+}
+
 // A genuinely unknown top-level field is the case worth alerting on.
 func TestAPIShapeMonitor_UnknownTopLevelField_Alerts(t *testing.T) {
 	m := NewAPIShapeMonitor()


### PR DESCRIPTION
The PrusaLink `/api/v1/status` endpoint can return an optional `filament_change_in` field in the `job` object when a slice contains a scheduled filament change. This field should be added to the allow-list to prevent false-positive API-change alerts.

Fixes #4